### PR TITLE
Fix README's LLVM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Old versions of Clang/LLVM, patched so that they can be built using more recent 
 
 There is a branch for each LLVM version that is supported.
 
-The patched version 2.9 has been shown to build successfully with:
+The patched version 2.7 has been shown to build successfully with:
 
-- gcc 11.3.0
+- gcc 11.4.0
 
 For some reason, the build process causes a change to this file in the source tree:
 
-- llvm-2.9/cmake/modules/LLVMLibDeps.cmake
+- llvm-2.7/cmake/modules/LLVMLibDeps.cmake

--- a/llvm-2.7/Makefile.rules
+++ b/llvm-2.7/Makefile.rules
@@ -586,7 +586,7 @@ endif
 # that if LOADABLE_MODULE is specified then the resulting shared library can
 # be opened with dlopen.
 ifdef LOADABLE_MODULE
-  LD.Flags += -module
+  LD.Flags += -Mmodules
 endif
 
 ifdef SHARED_LIBRARY
@@ -639,7 +639,7 @@ endif
 ifndef NO_PEDANTIC
 CompileCommonOpts += -pedantic -Wno-long-long
 endif
-CompileCommonOpts += -Wall -W -Wno-unused-parameter -Wwrite-strings \
+CompileCommonOpts += -Wall -W -Wno-unused-parameter -Wwrite-strings -Wno-deprecated-copy -Wno-misleading-indentation \
                      $(EXTRA_OPTIONS)
 
 ifeq ($(HOST_OS),HP-UX)

--- a/llvm-2.7/test/CMakeLists.txt
+++ b/llvm-2.7/test/CMakeLists.txt
@@ -22,8 +22,8 @@ else() # Default for all other unix like systems.
   set(SHLIBPATH_VAR "LD_LIBRARY_PATH")
 endif()
 
-include(FindPythonInterp)
-if(PYTHONINTERP_FOUND)
+include(FindPython2)
+if(Python2_Interpreter_FOUND)
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/site.exp.in
     ${CMAKE_CURRENT_BINARY_DIR}/site.exp)
@@ -46,7 +46,7 @@ if(PYTHONINTERP_FOUND)
                 -e "s#\@SHLIBPATH_VAR\@#${SHLIBPATH_VAR}#"
                 ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in >
                 ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${Python2_EXECUTABLE}
                 ${LLVM_SOURCE_DIR}/utils/lit/lit.py
                 --param llvm_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
                 --param llvm_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg

--- a/llvm-2.7/test/Scripts/macho-dump
+++ b/llvm-2.7/test/Scripts/macho-dump
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import struct
 import sys

--- a/llvm-2.7/unittests/Support/System.cpp
+++ b/llvm-2.7/unittests/Support/System.cpp
@@ -11,6 +11,6 @@ class SystemTest : public ::testing::Test {
 TEST_F(SystemTest, TimeValue) {
   sys::TimeValue now = sys::TimeValue::now();
   time_t now_t = time(NULL);
-  EXPECT_TRUE(abs(now_t - now.toEpochTime()) < 2);
+  EXPECT_TRUE(abs(static_cast<int>(now_t - now.toEpochTime())) < 2);
 }
 }


### PR DESCRIPTION
The README file incorrectly stated `llvm-2.9` instead of the correct
version, `llvm-2.7`. The confirmed `gcc` version that successfully built the
patched version has been updated to `11.4.0`.